### PR TITLE
Use str to report AttributeError exception

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -660,7 +660,7 @@ class Airflow(AirflowBaseView):
                 logs = handler.read(ti)
             except AttributeError as e:
                 logs = ["Task log handler {} does not support read logs.\n{}\n" \
-                            .format(task_log_reader, e.message)]
+                            .format(task_log_reader, str(e))]
 
         for i, log in enumerate(logs):
             if PY2 and not isinstance(log, unicode):


### PR DESCRIPTION
Received the following stack trace:

File ".../app/views.py", line 663, in log
    .format(task_log_reader, e.message)]
    AttributeError: 'AttributeError' object has no attribute 'message'