### PR TITLE
Show actual airflow version rather than deriving from pkg_resources

### DIFF
--- a/airflow_webserver/views.py
+++ b/airflow_webserver/views.py
@@ -2341,9 +2341,8 @@ class VersionView(AirflowBaseView):
     @expose('version')
     @has_access
     def version(self):
-        # Look at the version from setup.py
         try:
-            airflow_version = pkg_resources.require("apache-airflow")[0].version
+            airflow_version = airflow.__version__
         except Exception as e:
             airflow_version = None
             logging.error(e)


### PR DESCRIPTION
Currently, dependency handling in airflow/pip is broken.  At the moment,
airflow requires flask < 0.12, but airflow_webserver requires
flask_appbuilder==1.9.5, which requires flask >=0.12.1.  Since
dependency management in pip is non-robust, pip completes
the installation but invocations of pkg_resources.require
always fail.  This is a workaround.