### PR TITLE
Make airflow-webserver compatible with new type UtcDateTime

### DIFF
--- a/airflow_webserver/api/experimental/endpoints.py
+++ b/airflow_webserver/api/experimental/endpoints.py
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import logging
-
 import airflow.api
 
 from airflow.api.common.experimental import pool as pool_api
@@ -21,15 +18,16 @@ from airflow.api.common.experimental import trigger_dag as trigger
 from airflow.api.common.experimental.get_task import get_task
 from airflow.api.common.experimental.get_task_instance import get_task_instance
 from airflow.exceptions import AirflowException
-from airflow.www.app import csrf
+from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils import timezone
+from airflow_webserver import csrf
 
 from flask import (
     g, Markup, Blueprint, redirect, jsonify, abort,
     request, current_app, send_file, url_for
 )
-from datetime import datetime
 
-_log = logging.getLogger(__name__)
+_log = LoggingMixin().log
 
 requires_authentication = airflow.api.api_auth.requires_authentication
 
@@ -60,12 +58,11 @@ def trigger_dag(dag_id):
 
         # Convert string datetime into actual datetime
         try:
-            execution_date = datetime.strptime(execution_date,
-                                               '%Y-%m-%dT%H:%M:%S')
+            execution_date = timezone.parse(execution_date)
         except ValueError:
             error_message = (
                 'Given execution date, {}, could not be identified '
-                'as a date. Example date format: 2015-11-16T14:34:15'
+                'as a date. Example date format: 2015-11-16T14:34:15+00:00'
                 .format(execution_date))
             _log.info(error_message)
             response = jsonify({'error': error_message})
@@ -125,12 +122,11 @@ def task_instance_info(dag_id, execution_date, task_id):
 
     # Convert string datetime into actual datetime
     try:
-        execution_date = datetime.strptime(execution_date,
-                                           '%Y-%m-%dT%H:%M:%S')
+        execution_date = timezone.parse(execution_date)
     except ValueError:
         error_message = (
             'Given execution date, {}, could not be identified '
-            'as a date. Example date format: 2015-11-16T14:34:15'
+            'as a date. Example date format: 2015-11-16T14:34:15+00:00'
             .format(execution_date))
         _log.info(error_message)
         response = jsonify({'error': error_message})
@@ -164,10 +160,10 @@ def latest_dag_runs():
         if dagrun.execution_date:
             payload.append({
                 'dag_id': dagrun.dag_id,
-                'execution_date': dagrun.execution_date.strftime("%Y-%m-%d %H:%M"),
+                'execution_date': dagrun.execution_date.isoformat(),
                 'start_date': ((dagrun.start_date or '') and
-                               dagrun.start_date.strftime("%Y-%m-%d %H:%M")),
-                'dag_run_url': url_for('Airflow.graph', dag_id=dagrun.dag_id,
+                               dagrun.start_date.isoformat()),
+                'dag_run_url': url_for('airflow.graph', dag_id=dagrun.dag_id,
                                        execution_date=dagrun.execution_date)
             })
     return jsonify(items=payload)  # old flask versions dont support jsonifying arrays

--- a/airflow_webserver/decorators.py
+++ b/airflow_webserver/decorators.py
@@ -14,7 +14,7 @@
 
 import gzip
 import functools
-import dateutil.parser as dateparser
+import pendulum
 from io import BytesIO as IO
 from flask import after_this_request, request, g
 from airflow import models, settings
@@ -42,7 +42,7 @@ def action_logging(f):
             dag_id=request.args.get('dag_id'))
 
         if 'execution_date' in request.args:
-            log.execution_date = dateparser.parse(
+            log.execution_date = pendulum.parse(
                 request.args.get('execution_date'))
 
         session.add(log)

--- a/airflow_webserver/forms.py
+++ b/airflow_webserver/forms.py
@@ -20,6 +20,7 @@ from __future__ import unicode_literals
 from datetime import datetime
 
 from airflow import models
+from airflow.utils import timezone
 
 from flask_appbuilder.fieldwidgets import DateTimePickerWidget
 from flask_appbuilder.forms import DynamicForm
@@ -43,7 +44,7 @@ class DateTimeWithNumRunsForm(Form):
     # Date time and number of runs form for tree view, task duration
     # and landing times
     base_date = DateTimeField(
-        "Anchor date", widget=DateTimePickerWidget(), default=datetime.now())
+        "Anchor date", widget=DateTimePickerWidget(), default=timezone.utcnow())
     num_runs = SelectField("Number of runs", default=25, choices=(
         (5, "5"),
         (25, "25"),

--- a/airflow_webserver/utils.py
+++ b/airflow_webserver/utils.py
@@ -26,12 +26,12 @@ import wtforms
 import bleach
 import markdown
 
-from datetime import datetime
 from pygments import highlight, lexers
 from flask import request, Response, g, Markup, url_for
 from flask_login import current_user
 
 from airflow import configuration, models, settings
+from airflow.utils import timezone
 from airflow.utils.json import AirflowJsonEncoder
 from airflow.utils.state import State
 
@@ -202,8 +202,8 @@ def make_cache_key(*args, **kwargs):
 
 
 def task_instance_link(attr):
-    dag_id = bleach.clean(attr.get('dag_id'))
-    task_id = bleach.clean(attr.get('task_id'))
+    dag_id = bleach.clean(attr.get('dag_id')) if attr.get('dag_id') else None
+    task_id = bleach.clean(attr.get('task_id')) if attr.get('task_id') else None
     execution_date = attr.get('execution_date')
     url = url_for(
         'Airflow.task',
@@ -247,17 +247,17 @@ def nobr_f(attr_name):
 
 
 def datetime_f(attr_name):
-    def datetime(attr):
+    def dt(attr):
         f = attr.get(attr_name)
         f = f.isoformat() if f else ''
-        if datetime.now().isoformat()[:4] == f[:4]:
+        if timezone.utcnow().isoformat()[:4] == f[:4]:
             f = f[5:]
         return Markup("<nobr>{}</nobr>".format(f))
-    return datetime
+    return dt
 
 
 def dag_link(attr):
-    dag_id = bleach.clean(attr.get('dag_id'))
+    dag_id = bleach.clean(attr.get('dag_id')) if attr.get('dag_id') else None
     execution_date = attr.get('execution_date')
     url = url_for(
         'Airflow.graph',
@@ -268,8 +268,8 @@ def dag_link(attr):
 
 
 def dag_run_link(attr):
-    dag_id = bleach.clean(attr.get('dag_id'))
-    run_id = bleach.clean(attr.get('run_id'))
+    dag_id = bleach.clean(attr.get('dag_id')) if attr.get('dag_id') else None
+    run_id = bleach.clean(attr.get('run_id')) if attr.get('run_id') else None
     execution_date = attr.get('execution_date')
     url = url_for(
         'Airflow.graph',


### PR DESCRIPTION
This change will make airflow-webserver compatible with the new timezone feature in master.
Also created PR https://github.com/dpgaspar/Flask-AppBuilder/pull/694 to patch FAB side as well in order to properly display any model views that contains Custom SqlAlchemy Types.